### PR TITLE
client: fix flaky test

### DIFF
--- a/naming/client_test.go
+++ b/naming/client_test.go
@@ -80,7 +80,6 @@ func TestDiscovery(t *testing.T) {
 		dis.node.Store([]string{"127.0.0.1:7171"})
 		_ = dis.renew(context.TODO(), instance)
 		Convey("test discovery set", func() {
-			rs := dis.Build(appid)
 			inSet := &Instance{
 				Region:   "test",
 				Zone:     "test",
@@ -98,6 +97,7 @@ func TestDiscovery(t *testing.T) {
 			}
 			err = dis.Set(inSet)
 			So(err, ShouldBeNil)
+			rs := dis.Build(appid)
 			ch := rs.Watch()
 			<-ch
 			ins, _ := rs.Fetch()


### PR DESCRIPTION
TestDiscovery 的  test discovery set 测试中，
原先的顺序是
1. dis.Build(appid)
2. dis.Set(inSet)
3. 等待变化通知 && rs.Fetch()

这里有一个 race condition:
1. dis.Build 会导致 polls 重启，必然产生变化通知
2. dis.Set 的更新会被在另外一个 goroutine 里面运行的 serverproc处理
3. dis.Set 后不能保证 rs.Fetch() 取得到最新的信息

改为
1. dis.Set(inSet)
2. dis.Build(appid)
3. 等待变化通知 & rs.Fetch()