### PR TITLE
fix: 跳过无效的discovery节点

### DIFF
--- a/naming/client.go
+++ b/naming/client.go
@@ -549,7 +549,6 @@ func (d *Discovery) polls(ctx context.Context) (apps map[string]*InstancesInfo, 
 		params.Add("latest_timestamp", strconv.FormatInt(ts, 10))
 	}
 	if err = d.httpClient.Get(ctx, uri, "", params, res); err != nil {
-		d.switchNode()
 		if ctx.Err() != context.Canceled {
 			log.Error("discovery: client.Get(%s) error(%+v)", uri+"?"+params.Encode(), err)
 		}

--- a/naming/client_test.go
+++ b/naming/client_test.go
@@ -108,6 +108,7 @@ func TestDiscovery(t *testing.T) {
 		})
 	})
 	Convey("test discovery watch", t, func() {
+		dis.node.Store([]string{"127.0.0.1:7172", "127.0.0.1:7171"})
 		rsl := dis.Build(appid)
 		ch := rsl.Watch()
 		<-ch


### PR DESCRIPTION
调用`polls()`的`for`循环里面,若检测到返回失败, 就会调用`d.switchNode()`切换节点.
若`polls`中也切换节点,有可能会正好跳过了可用的那个节点.
所以,需要将`polls`里面切换节点的代码移除掉.

测试代码中添加了一行,用于复现该问题.