### PR TITLE
fix: 当内存中的discovery节点全都无效时,尝试连接到配置文件中的节点.

### DIFF
--- a/naming/client.go
+++ b/naming/client.go
@@ -147,7 +147,9 @@ func (d *Discovery) selfproc(resolver Resolver, event <-chan struct{}) {
 }
 
 func (d *Discovery) newSelf(zones map[string][]*Instance) {
+	d.mutex.Lock()
 	ins, ok := zones[d.c.Zone]
+	d.mutex.Unlock()
 	if !ok {
 		return
 	}

--- a/naming/client_test.go
+++ b/naming/client_test.go
@@ -100,6 +100,7 @@ func TestDiscovery(t *testing.T) {
 			}
 			err = dis.Set(inSet)
 			So(err, ShouldBeNil)
+			dis.node.Store([]string{"127.0.0.1:7172"})
 			rs := dis.Build(appid)
 			ch := rs.Watch()
 			<-ch


### PR DESCRIPTION
有可能内存中的discovery节点,并不包含配置文件中定义的节点地址.
若内存中的节点全都无效了, 应该尝试重新到配置文件中指定的地址去获取.

比如在k8s中,定义discovery的地址是服务的dns地址.而连接成功后,实际上获取的是discovery的Pod的地址.若相应的单点Pod重启了,就会出现始终无法连接上新discovery的状况.
若在一定次数的网络故障后,主动根据配置文件中的地址,去连接discovery,就可以获取到最新的discovery地址了.