### PR TITLE
 Fixing program runtime errors

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -1,7 +1,15 @@
+/*
+ * @Author: gitsrc
+ * @Date: 2020-09-04 09:57:29
+ * @LastEditors: gitsrc
+ * @LastEditTime: 2020-09-04 10:05:14
+ * @FilePath: /discovery/discovery/discovery.go
+ */
 package discovery
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -17,6 +25,7 @@ type Discovery struct {
 	client    *http.Client
 	registry  *registry.Registry
 	nodes     atomic.Value
+	sync.RWMutex
 }
 
 // New get a discovery.
@@ -38,5 +47,7 @@ func New(c *conf.Config) (d *Discovery, cancel context.CancelFunc) {
 func (d *Discovery) exitProtect() {
 	// exist protect mode after two renew cycle
 	time.Sleep(time.Second * 60)
+	d.Lock()
 	d.protected = false
+	d.Unlock()
 }

--- a/discovery/syncup.go
+++ b/discovery/syncup.go
@@ -21,8 +21,11 @@ var (
 // Protected return if service in init protect mode.
 // if service in init protect mode,only support write,
 // read operator isn't supported.
-func (d *Discovery) Protected() bool {
-	return d.protected
+func (d *Discovery) Protected() (ret bool) {
+	d.RLock()
+	ret = d.protected
+	d.RUnlock()
+	return ret
 }
 
 // syncUp populates the registry information from a peer eureka node.
@@ -46,7 +49,9 @@ func (d *Discovery) syncUp() {
 			continue
 		}
 		// sync success from other node,exit protected mode
+		d.Lock()
 		d.protected = false
+		d.Unlock()
 		for _, is := range res.Data {
 			for _, i := range is {
 				_ = d.registry.Register(i, i.LatestTimestamp)

--- a/model/instance.go
+++ b/model/instance.go
@@ -203,8 +203,30 @@ func (p *Apps) InstanceInfo(zone string, latestTime int64, status uint32) (ci *I
 		err = ecode.NothingFound
 	} else if len(ci.Instances) == 0 {
 		err = ecode.NotModified
+	} else if status == 1 && !getUpInstance(ci) {
+		// When obtaining the online status of the microservice, verify whether the array is empty, and return a 404 status code if it is an empty array
+		err = ecode.NothingFound
+		ci = nil
 	}
+
 	return
+}
+
+func getUpInstance(ins *InstanceInfo) bool {
+	isExist := false
+	for _, v := range ins.Instances {
+		for _, ins := range v {
+			if len(ins.Addrs[0]) == 0 || ins.Status != 1 {
+				continue
+			}
+			isExist = true
+			break
+		}
+		if isExist {
+			break
+		}
+	}
+	return isExist
 }
 
 // UpdateLatest update LatestTimestamp.

--- a/model/instance.go
+++ b/model/instance.go
@@ -204,7 +204,6 @@ func (p *Apps) InstanceInfo(zone string, latestTime int64, status uint32) (ci *I
 	} else if len(ci.Instances) == 0 {
 		err = ecode.NotModified
 	} else if status == 1 && !getUpInstance(ci) {
-		// When obtaining the online status of the microservice, verify whether the array is empty, and return a 404 status code if it is an empty array
 		err = ecode.NothingFound
 		ci = nil
 	}


### PR DESCRIPTION
1. When obtaining the online status of the microservice, verify whether the array is empty, and return a 404 status code if it is an empty array
2. Fix concurrent race exception: When discovery is incorrectly configured with the same hostname, client registration will trigger a data race.