### PR TITLE
fix: get default conf env from kratos

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/BurntSushi/toml"
+	"github.com/bilibili/kratos/pkg/conf/env"
 	"github.com/bilibili/kratos/pkg/conf/paladin"
 	log "github.com/bilibili/kratos/pkg/log"
 	http "github.com/bilibili/kratos/pkg/net/http/blademaster"
@@ -72,8 +73,16 @@ type Env struct {
 	DeployEnv string
 }
 
+// Fix default env from kartos
+func fixDefEnv() {
+	region = env.Region
+	zone = env.Zone
+	deployEnv = env.DeployEnv
+}
+
 // Init init conf
 func Init() (err error) {
+	fixDefEnv()
 	if err = paladin.Init(); err != nil {
 		return
 	}


### PR DESCRIPTION
现在,命令行传递的参数 `region` `zone` `deploy.env` 被 `kartos`取走了.
原有`conf`下的默认值就为空了.

现在,如果`discovery-example.toml`中的`env`字段为空,就没法通过命令行的方式来指定`conf`中的`env`了.