### PR TITLE
refactor(node): clear invalid request param

### DIFF
--- a/registry/node.go
+++ b/registry/node.go
@@ -126,7 +126,6 @@ func (n *Node) call(c context.Context, action model.Action, i *model.Instance, u
 		params.Set("version", i.Version)
 		meta, _ := json.Marshal(i.Metadata)
 		params.Set("metadata", string(meta))
-		params.Set("reg_timestamp", strconv.FormatInt(i.RegTimestamp, 10))
 		params.Set("dirty_timestamp", strconv.FormatInt(i.DirtyTimestamp, 10))
 		params.Set("latest_timestamp", strconv.FormatInt(i.LatestTimestamp, 10))
 	case model.Renew:


### PR DESCRIPTION
1.Http接口定义，似乎没有接收 `reg_timestamp` 字段，因此判定为 无效字段。
![image](https://user-images.githubusercontent.com/19775205/139781323-a7d748db-93ea-446e-9e6e-2c98bf7ecf9a.png)

2.清理 “无效字段“ 有利于 同行阅读源码，理解逻辑。
3.清理 ”无效字段“ 有利于降低 网络传输成本。
